### PR TITLE
Minimum Electron version support for Apple Silicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/trodi/electron-splashscreen#readme",
   "devDependencies": {
-    "electron": "^6.0.2",
+    "electron": "^11.0.1",
     "tslint": "^5.7.0",
     "typedoc": "^0.15.6",
     "typedoc-plugin-markdown": "^2.2.16",


### PR DESCRIPTION
Addresses this error for NPM install:

> npm ERR! npm ERR! Error: Failed to find Electron v6.1.7 for darwin-arm64 at https://github.com/electron/electron/releases/download/v6.1.7/electron-v6.1.7-darwin-arm64.zip

Apple Silicon has a minimum electron version